### PR TITLE
FIN-648 Modifying Docker image and Tomcat startup to include running …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ ENV SECURITY_DIRECTORY=/security
 ENV SMTP_SECURITY_DIRECTORY=/security/smtp
 ENV TOMCAT_CONFIG_DIRECTORY=/configuration/tomcat-config
 ENV RICE_CONFIG_DIRECTORY=/configuration/rice-config
+ENV UA_DB_CHANGELOGS_DIR=$TOMCAT_RICE_DIR/changelogs
 
 # copy in the new relic jar file
 COPY classes $TOMCAT_SHARE_LIB

--- a/bin/liquibase_rice.sh
+++ b/bin/liquibase_rice.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# liquibase_rice.sh: main liquibase script based on liquibase_kfs.sh
+# Calls liquibase with correct database parameters
+# for this environment, path to ojdbc6.jar file.
+
+LIQUIBASE_HOME=$TOMCAT_SHARE_LIB
+RICE_CONFIG_FILE=$RICE_CONFIG_DIRECTORY/rice-config.xml
+
+# username, password and url are passed in from the rice config file
+LIQUIBASE_DB_USERNAME=$(grep "datasource.username" $RICE_CONFIG_FILE | sed -e 's/^[ \t]*//' | sed -e 's/<param name="datasource\.username">//' | sed -e 's/<\/param>//')
+LIQUIBASE_DB_PASSWORD=$(grep "datasource.password" $RICE_CONFIG_FILE | sed -e 's/^[ \t]*//' | sed -e 's/<param name="datasource\.password">//' | sed -e 's/<\/param>//')
+LIQUIBASE_DB_URL=$(grep "datasource.url" $RICE_CONFIG_FILE | sed -e 's/^[ \t]*//' | sed -e 's/<param name="datasource\.url">//' | sed -e 's/<\/param>//')
+
+exec /usr/bin/java -jar $LIQUIBASE_HOME/liquibase-3.3.5.jar \
+--url="$LIQUIBASE_DB_URL" \
+--username=$LIQUIBASE_DB_USERNAME \
+--password=$LIQUIBASE_DB_PASSWORD \
+--classpath=$TOMCAT_SHARE_LIB/ojdbc6.jar \
+--driver=oracle.jdbc.driver.OracleDriver \
+--logLevel=info \
+$@

--- a/bin/liquibase_rice_update.sh
+++ b/bin/liquibase_rice_update.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#Update Database with Liquibase Changesets if they exist
+LIQUIBASE_BIN=/usr/local/bin/
+LIQUIBASE_CHANGELOG_DIR=$UA_DB_CHANGELOGS_DIR/edu/arizona/changelog
+APP_VERSION=$1
+
+cd $LIQUIBASE_CHANGELOG_DIR
+
+LIQUIBASE_STATUS=$($LIQUIBASE_BIN/liquibase_rice.sh --changeLogFile=db.changelog-master.xml status)
+ if [[ $LIQUIBASE_STATUS =~ "change sets have not been applied" ]]; then
+  $LIQUIBASE_BIN/liquibase_rice.sh --changeLogFile=db.changelog-master.xml update
+  $LIQUIBASE_BIN/liquibase_rice.sh tag $APP_VERSION
+ fi 

--- a/bin/tomcat-ctl
+++ b/bin/tomcat-ctl
@@ -79,6 +79,28 @@ tomcat_start () {
     echo_time "Copying jar files to Tomcat lib directory."
     cp $TOMCAT_CONFIG_DIRECTORY/classes/* $TOMCAT_SHARE_LIB/
 
+    # Get changelogs for liquibase
+    log "Loading changelog files for liquibase."
+    echo_time "Loading changelog files for liquibase"
+
+    # create new directory to hold the UA changelog files
+    mkdir -p $UA_DB_CHANGELOGS_DIR
+
+    # copy rice-db-ua .jar to changelogs directory and extract files
+    cp $TOMCAT_RICE_DIR/WEB-INF/lib/rice-db-ua* $UA_DB_CHANGELOGS_DIR/
+    cd $UA_DB_CHANGELOGS_DIR/
+    unzip rice-db-ua*.jar
+    cd -
+
+    # run liquibase here
+    # tag with KFS_ENV_NAME until we figure out how to pass in build version like on-premise docker container work
+    log "Running liquibase update."
+    echo_time "Running liquibase update."
+    liquibase_rice_update.sh $KFS_ENV_NAME >> $LOGS_DIRECTORY/$RICE_STARTUP_LOG 2>&1 &
+
+    log "Completed running liquibase update"
+    echo_time "Completed running liquibase update"
+
     # Copy authinfo and regenerate authinfo.db after initial file creation on EC2 instance via CF and OpsWorks
     # Related documentation: http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sendmail.html
     cp $SMTP_SECURITY_DIRECTORY/authinfo /etc/mail/


### PR DESCRIPTION
…liquibase.

Tech notes:
1. The rice-db-ua jar is assumed to be in the standalone rice war.
2. The jar tool is not available in our OpenJDK 8, so unzip is used.
3. Extracting the rice database credentials and url assumes an XML file based on the rice-config template.